### PR TITLE
Adjustments to the `Amazon Linux` Block:

### DIFF
--- a/install_userify_server.sh
+++ b/install_userify_server.sh
@@ -33,18 +33,17 @@ fi
 # full redis server with client hiredis.x86_64
 #
 
-if [[ $(uname -a | grep amzn) ]]; then
+if uname -a | grep -q amzn; then
     # Error: Package: redis-2.8.19-2.el7.x86_64 (epel)
     # Requires: systemd
     cat <<- EOF
-Amazon Linux does not support installation of Redis, so this script does not
-support installation on Amazon Linux.  However, if you install Redis on Amazon
-Linux separately, or if you are using Userify Enterprise with a non-local Redis
-server, then please review this script and install separately. (Be sure to snap
-an AMI afterward.) Also, if you need additional assitance, or would like a
-pre-installed Userify server published to your AWS account at no additional
-charge, please contact support.
+Amazon Linux does not support the installation of the Redis Database, so this script does not currently support installing on Amazon\'s Linux.
 
+However, if you install Redis on Amazon\'s Linux separately, or if you are using Userify Enterprise with a non-local Redis server, then please review this script and proceed to install separately.
+
+NOTE: Please be sure to snap an AMI afterward
+
+Also, if you need additional assitance or would like a pre-installed, no-hassle Userify server published to your AWS account at no additional charge, please feel free to contact our support department!
 EOF
     exit 1
 fi

--- a/install_userify_server.sh
+++ b/install_userify_server.sh
@@ -48,7 +48,7 @@ EOF
     exit 1
 fi
 
-epel_release="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+epel_release=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 # RHEL/CentOS PREREQUISITES
 function rhel_prereqs {
@@ -98,8 +98,8 @@ function debian_prereqs {
 }
 
 
-$SUDO command -v yum 2>/dev/null && rhel_prereqs
-$SUDO command -v apt-get 2>/dev/null && debian_prereqs
+$SUDO which yum 2>/dev/null && rhel_prereqs
+$SUDO which apt-get 2>/dev/null && debian_prereqs
 
 # ALL DISTRIBUTIONS
 
@@ -114,7 +114,7 @@ $SUDO command -v apt-get 2>/dev/null && debian_prereqs
 
 set -e
 PATH="/usr/local/bin/:/usr/local/sbin/:$PATH"
-pip=$(command -v pip)
+pip=$(which pip)
 $SUDO $pip install --upgrade \
     cffi \
     ndg-httpsclient \
@@ -291,11 +291,11 @@ fi
 [ -f /usr/sbin/update-rc.d ] && $SUDO update-rc.d userify-server defaults
 set +e
 # needed for docker
-$SUDO "$(command -v systemctl)" && $SUDO systemctl enable redis-server
-$SUDO "$(command -v systemctl)" && $SUDO systemctl enable userify-server
+$SUDO $(which systemctl) && $SUDO systemctl enable redis-server
+$SUDO $(which systemctl) && $SUDO systemctl enable userify-server
 set -e
 
-$SUDO /opt/userify-server/userify-start 2>&1 | $SUDO tee /var/log/userify-server.log >/dev/null &
+$SUDO /opt/userify-server/userify-start 2>&1 |$SUDO tee /var/log/userify-server.log >/dev/null &
 
 sleep 1
 

--- a/install_userify_server.sh
+++ b/install_userify_server.sh
@@ -48,7 +48,7 @@ EOF
     exit 1
 fi
 
-epel_release=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+epel_release="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 
 # RHEL/CentOS PREREQUISITES
 function rhel_prereqs {
@@ -98,8 +98,8 @@ function debian_prereqs {
 }
 
 
-$SUDO which yum 2>/dev/null && rhel_prereqs
-$SUDO which apt-get 2>/dev/null && debian_prereqs
+$SUDO command -v yum 2>/dev/null && rhel_prereqs
+$SUDO command -v apt-get 2>/dev/null && debian_prereqs
 
 # ALL DISTRIBUTIONS
 
@@ -114,7 +114,7 @@ $SUDO which apt-get 2>/dev/null && debian_prereqs
 
 set -e
 PATH="/usr/local/bin/:/usr/local/sbin/:$PATH"
-pip=$(which pip)
+pip=$(command -v pip)
 $SUDO $pip install --upgrade \
     cffi \
     ndg-httpsclient \
@@ -291,11 +291,11 @@ fi
 [ -f /usr/sbin/update-rc.d ] && $SUDO update-rc.d userify-server defaults
 set +e
 # needed for docker
-$SUDO $(which systemctl) && $SUDO systemctl enable redis-server
-$SUDO $(which systemctl) && $SUDO systemctl enable userify-server
+$SUDO "$(command -v systemctl)" && $SUDO systemctl enable redis-server
+$SUDO "$(command -v systemctl)" && $SUDO systemctl enable userify-server
 set -e
 
-$SUDO /opt/userify-server/userify-start 2>&1 |$SUDO tee /var/log/userify-server.log >/dev/null &
+$SUDO /opt/userify-server/userify-start 2>&1 | $SUDO tee /var/log/userify-server.log >/dev/null &
 
 sleep 1
 

--- a/install_userify_server.sh
+++ b/install_userify_server.sh
@@ -149,6 +149,8 @@ $SUDO $pip install --upgrade \
     cryptography \
     paste \
     apache-libcloud \
+    service_identity \
+    ldaptor \
 
 
 # OLD Python versions (python <= 2.5) also need ssl installed:

--- a/install_userify_server.sh
+++ b/install_userify_server.sh
@@ -43,7 +43,7 @@ However, if you install Redis on Amazon\'s Linux separately, or if you are using
 
 NOTE: Please be sure to snap an AMI afterward
 
-Also, if you need additional assitance or would like a pre-installed, no-hassle Userify server published to your AWS account at no additional charge, please feel free to contact our support department!
+Also, if you need additional assistance or would like a pre-installed, no-hassle Userify server published to your AWS account at no additional charge, please feel free to contact our support department!
 EOF
     exit 1
 fi

--- a/install_userify_server.sh
+++ b/install_userify_server.sh
@@ -37,7 +37,7 @@ if uname -a | grep -q amzn; then
     # Error: Package: redis-2.8.19-2.el7.x86_64 (epel)
     # Requires: systemd
     cat <<- EOF
-Amazon Linux does not support the installation of the Redis Database, so this script does not currently support installing on Amazon\'s Linux.
+Amazon\'s Linux does not support the installation of the Redis Database, so this installation script is not meant for - and we do not provide support for -  running this on Amazon\'s Linux.
 
 However, if you install Redis on Amazon\'s Linux separately, or if you are using Userify Enterprise with a non-local Redis server, then please review this script and proceed to install separately.
 

--- a/install_userify_server.sh
+++ b/install_userify_server.sh
@@ -37,13 +37,19 @@ if uname -a | grep -q amzn; then
     # Error: Package: redis-2.8.19-2.el7.x86_64 (epel)
     # Requires: systemd
     cat <<- EOF
-Amazon\'s Linux does not support the installation of the Redis Database, so this installation script is not meant for - and we do not provide support for -  running this on Amazon\'s Linux.
+Amazon's Linux on AWS does not support the installation of the Redis Database, 
+so this installation script is not meant for - and we do not provide support for - 
+running this on Amazon's Linux.
 
-However, if you install Redis on Amazon\'s Linux separately, or if you are using Userify Enterprise with a non-local Redis server, then please review this script and proceed to install separately.
+However, if you install Redis on Amazon's Linux separately, or if you are using 
+Userify Enterprise with a non-local Redis server, then please review this script 
+and proceed to install separately.
 
 NOTE: Please be sure to snap an AMI afterward
 
-Also, if you need additional assistance or would like a pre-installed, no-hassle Userify server published to your AWS account at no additional charge, please feel free to contact our support department!
+Also, if you need additional assistance or would like a pre-installed, no-hassle 
+Userify Server published to your AWS account at no additional charge, please feel 
+free to contact our support department!
 EOF
     exit 1
 fi


### PR DESCRIPTION
- Amended the `if` test line to match up with [this shellcheck code](https://github.com/koalaman/shellcheck/wiki/SC2143)

- Grammatical, spacing and verbiage adjustments to the actual warning message output regarding Amazon's Linux version:
  1. Detailing that Amazon doesn't support Redis
  2. Using apostraphes to show Amazon's ownership over their servers
  3. Putting more attention on the option for a simple, premade userify instance.